### PR TITLE
Fix a typo from osutil.Environ removal.

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -66,7 +66,7 @@ type mb struct {
 }
 
 func (b *mb) cdir(dir string) {
-	b.environ = append(b.environ, "PWD"+dir)
+	b.environ = append(b.environ, "PWD="+dir)
 	b.dir = dir
 }
 


### PR DESCRIPTION
For some reason, I was looking over my PR #4 again, and I noticed a typo. When setting the environment variable, it needs an `=` between key and value.